### PR TITLE
publisherモデルのバリデーションに対するテストを実装

### DIFF
--- a/spec/factories/publishers.rb
+++ b/spec/factories/publishers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :publisher do
+    sequence(:name)   { |n| "テスト#{n}" }
+    user_id           { User.first.id }
+  end
+end

--- a/spec/models/publisher_spec.rb
+++ b/spec/models/publisher_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe Publisher, type: :model do
+
+  before do
+    FactoryBot.create(:subject)
+    FactoryBot.create(:club)
+    FactoryBot.create(:kinds_of_school)
+    FactoryBot.create(:user)
+  end
+
+  let(:publisher) { FactoryBot.create(:publisher) }
+
+  it "is valid with name, user_id" do
+    expect(publisher).to be_valid
+  end
+
+  it "is invalid without name" do
+    publisher.name = ""
+    expect(publisher).to_not be_valid
+  end
+
+  it "is invalid without user_id" do
+    publisher.user_id = nil
+    expect(publisher).to_not be_valid
+  end
+
+  it "is valid when name is less than 50 characters" do
+    publisher.name = "a" * 50
+    expect(publisher).to be_valid
+  end
+
+  it "is invalid when name is more 51 characters" do
+    publisher.name = "a" * 51
+    expect(publisher).to_not be_valid
+  end
+
+  it "is valid when name is unique" do
+    publisher.save
+    duplicate_publisher = publisher.dup
+    expect(duplicate_publisher).to_not be_valid
+  end
+
+end


### PR DESCRIPTION
### 実装内容
* nameとuser_idの存在性のチェック
* nameの文字数に対するチェック
* nameの一意性に対するチェック