### PR TITLE
部活動一覧 / 部活動詳細に関するテストを実装

### DIFF
--- a/app/controllers/club_posts_controller.rb
+++ b/app/controllers/club_posts_controller.rb
@@ -8,7 +8,7 @@ class ClubPostsController < ApplicationController
       redirect_back(fallback_location: root_url)
     else
       @group = Club.find(params[:id])
-      @posts = ClubPost.where(club_id: params[:id])
+      @posts = ClubPost.where(club_id: params[:id]).page(params[:page]).per(30)
       render 'clubs/show', status: :unprocessable_entity
     end
   end

--- a/app/controllers/club_posts_controller.rb
+++ b/app/controllers/club_posts_controller.rb
@@ -5,23 +5,27 @@ class ClubPostsController < ApplicationController
   def create
     @post = current_user.club_posts.build(club_post_params)
     if @post.save
+      flash[:success] = "新規投稿を行いました！"
       redirect_back(fallback_location: root_url)
     else
-      @group = Club.find(params[:id])
-      @posts = ClubPost.where(club_id: params[:id]).page(params[:page]).per(30)
+      flash.now[:danger] = "新規投稿に失敗しました..."
+      @group = Club.find(club_post_params[:club_id])
+      @posts = ClubPost.where(club_post_params[:club_id]).page(params[:page]).per(30)
       render 'clubs/show', status: :unprocessable_entity
     end
   end
 
   def destroy
+    content = @club_post.content
     @club_post.destroy
+    flash[:success] = "投稿(#{content})を削除しました"
     redirect_back(fallback_location: root_url, status: :see_other)
   end
 
   private
 
     def club_post_params
-      params.require(:club_post).permit(:content, :club_id)
+      params.require(:club_post).permit(:club_id, :content)
     end
 
     def correct_user

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -7,7 +7,7 @@ class ClubsController < ApplicationController
 
   def show
     @post = current_user.club_posts.build if logged_in?
-    @posts = ClubPost.where(club_id: params[:id])
+    @posts = ClubPost.where(club_id: params[:id]).page(params[:page]).per(30)
   end
 
   def members

--- a/app/controllers/subject_posts_controller.rb
+++ b/app/controllers/subject_posts_controller.rb
@@ -25,7 +25,7 @@ class SubjectPostsController < ApplicationController
   private
 
     def subject_post_params
-      params.require(:subject_post).permit(:content, :subject_id)
+      params.require(:subject_post).permit(:subject_id, :content)
     end
 
     # before フィルタ

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -1,4 +1,6 @@
 <% provide(:title, @group.name) %>
-<% provide(:params_id, "club_id") %>
 
-<%= render 'shared/group_show' %>
+<h1 class="text-center"><%= yield(:title) %></h1>
+
+<%= render 'shared/post_form', params_id: "club_id" %>
+<%= render 'shared/post' %>

--- a/app/views/kinds_of_schools/show.html.erb
+++ b/app/views/kinds_of_schools/show.html.erb
@@ -1,4 +1,6 @@
 <% provide(:title, @group.name) %>
-<% provide(:params_id, "kinds_of_school_id") %>
 
-<%= render 'shared/group_show' %>
+<h1 class="text-center"><%= yield(:title) %></h1>
+
+<%= render 'shared/post_form' %>
+<%= render 'shared/post' %>

--- a/app/views/shared/_post_form.html.erb
+++ b/app/views/shared/_post_form.html.erb
@@ -3,7 +3,7 @@
   <%= form_with(model: @post) do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
-    <div><%= f.hidden_field "subject_id", :value => @group.id %></div>
+    <div><%= f.hidden_field params_id, :value => @group.id %></div>
     <div class="field">
       <%= f.text_area :content, style: "width: 100%;" %>
     </div>

--- a/app/views/subjects/show.html.erb
+++ b/app/views/subjects/show.html.erb
@@ -2,5 +2,5 @@
 
 <h1 class="text-center"><%= yield(:title) %></h1>
 
-<%= render 'shared/post_form' %>
+<%= render 'shared/post_form', params_id: "subject_id" %>
 <%= render 'shared/post' %>

--- a/spec/features/club_spec.rb
+++ b/spec/features/club_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 RSpec.feature "Clubs", type: :feature do
 
-  let(:baseball) { Club.first }
+  let(:michael)    { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
+  let(:baseball)   { Club.first }
 
   scenario "show clubs_index" do
     visit root_path
@@ -36,6 +38,45 @@ RSpec.feature "Clubs", type: :feature do
 
     baseball.users.page(1).per(30).each do |member|
       expect(page).to have_link member.name, href: user_path(member)
+    end
+  end
+
+  feature "club_posts" do
+    scenario "create new posts and delete posts" do
+      login(michael)
+      visit root_path
+
+      click_link "部活動一覧"
+      click_link baseball.name
+
+      expect {
+        fill_in "club_post[content]", with: "1番目の投稿です！"
+        click_button "投稿"
+        fill_in "club_post[content]", with: "2番目の投稿です！"
+        click_button "投稿"
+        fill_in "club_post[content]", with: "最新の投稿です！"
+        click_button "投稿"
+      }.to change { baseball.club_posts.count }.by(3)
+
+      expect(page).to have_content("新規投稿を行いました！")
+      expect(page).to have_content("1番目の投稿です！")
+      expect(page).to have_content("2番目の投稿です！")
+      expect(page).to have_content("最新の投稿です！")
+
+      expect {
+        first("#delete_btn#{baseball.club_posts.first.id}").click
+      }.to change {baseball.club_posts.count}.by(-1)
+
+      expect(page).to have_text("投稿(最新の投稿です！)を削除しました")
+      expect(page).to have_content("1番目の投稿です！")
+      expect(page).to have_content("2番目の投稿です！")
+
+      logout
+
+      login(other_user)
+      visit club_path(baseball)
+
+      expect(page).to_not have_content("投稿の削除")
     end
   end
 

--- a/spec/features/club_spec.rb
+++ b/spec/features/club_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature "Clubs", type: :feature do
+
+  scenario "show clubs_index" do
+    visit root_path
+
+    click_link "部活動一覧"
+
+    Club.all.each do |club|
+      expect(page).to have_link club.name, href: club_path(club)
+    end
+  end
+
+  
+
+end

--- a/spec/features/club_spec.rb
+++ b/spec/features/club_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.feature "Clubs", type: :feature do
 
+  let(:baseball) { Club.first }
+
   scenario "show clubs_index" do
     visit root_path
 
@@ -12,6 +14,29 @@ RSpec.feature "Clubs", type: :feature do
     end
   end
 
-  
+  scenario "layout of clubs_show" do
+
+    50.times do
+      user = FactoryBot.create(:user, club_id: baseball.id)
+      user.club_posts.create!(content: "テスト投稿", club_id: baseball.id)
+    end
+
+    visit root_path
+
+    click_link "部活動一覧"
+    click_link baseball.name
+
+    expect(page).to have_selector('ul.pagination')
+    baseball.club_posts.page(1).per(30).each do |post|
+      expect(page).to have_content(post.user.name)
+      expect(page).to have_content(post.content)
+    end
+
+    click_link "ユーザー"
+
+    baseball.users.page(1).per(30).each do |member|
+      expect(page).to have_link member.name, href: user_path(member)
+    end
+  end
 
 end

--- a/spec/features/club_spec.rb
+++ b/spec/features/club_spec.rb
@@ -78,6 +78,22 @@ RSpec.feature "Clubs", type: :feature do
 
       expect(page).to_not have_content("投稿の削除")
     end
+
+    scenario "creating post is failed" do
+      login(michael)
+      visit root_path
+
+      click_link "部活動一覧"
+      click_link baseball.name
+
+      expect {
+        fill_in "club_post[content]", with: ""
+        click_button "投稿"
+      }.to_not change { baseball.club_posts.count }
+
+      expect(page).to have_text("新規投稿に失敗しました")
+      expect(page).to have_css('div#validation_messages')
+    end
   end
 
 end

--- a/spec/features/subject_spec.rb
+++ b/spec/features/subject_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Subjects", type: :feature do
         click_button "投稿"
         fill_in "subject_post[content]", with: "最新の投稿です！"
         click_button "投稿"
-      }.to change {japanese.subject_posts.count}.by(3)
+      }.to change { japanese.subject_posts.count }.by(3)
 
       expect(page).to have_content("新規投稿を行いました！")
       expect(page).to have_content("1番目の投稿です！")

--- a/spec/features/subject_spec.rb
+++ b/spec/features/subject_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature "Subjects", type: :feature do
       expect(page).to_not have_content("投稿の削除")
     end
 
-    scenario "new post is failed" do
+    scenario "creating post is failed" do
       login(michael)
       visit root_path
 
@@ -89,10 +89,10 @@ RSpec.feature "Subjects", type: :feature do
       expect {
         fill_in "subject_post[content]",    with: ""
         click_button "投稿"
-      }.to_not change {japanese.subject_posts.count}
+      }.to_not change { japanese.subject_posts.count }
 
       expect(page).to have_text("新規投稿に失敗しました...")
-      expect(page).to have_content("投稿内容は必須項目です")
+      expect(page).to have_css('div#validation_messages')
     end
   end
 

--- a/spec/features/subject_spec.rb
+++ b/spec/features/subject_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Subjects", type: :feature do
     end
   end
 
-  scenario "layout of subject_show" do
+  scenario "layout of subjects_show" do
 
     50.times do
       user = FactoryBot.create(:user, subject_id: japanese.id)


### PR DESCRIPTION
### 実装内容
* 部活動一覧ページのレイアウトをテスト
* 部活動詳細画面のレイアウトをテスト
* 投稿の新規作成および削除に関する結合テストの実装
* 投稿失敗時のテストを実装