### PR TITLE
出版社の新規登録機能に関するテストの実装

### DIFF
--- a/app/controllers/publishers_controller.rb
+++ b/app/controllers/publishers_controller.rb
@@ -18,7 +18,7 @@ class PublishersController < ApplicationController
   def create
     @publisher = current_user.publishers.build(publisher_params)
     if @publisher.save
-      flash[:success] = "新しい出版社を登録しました！！"
+      flash[:success] = "新しい出版社を登録しました！"
       redirect_to publishers_url
     else
       flash.now[:danger] = "出版社の登録に失敗しました..."

--- a/app/views/publishers/_form.html.erb
+++ b/app/views/publishers/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with(model: @publisher) do |f| %>
+  <%= render 'shared/error_messages', model: f.object %>
 
   <%= f.label :name, "出版社名" %> <br>
   <%= f.text_field :name, class: 'form-control' %> <br>

--- a/spec/features/private_group/private_group_create_spec.rb
+++ b/spec/features/private_group/private_group_create_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "PrivateGroupCreates", type: :feature do
         click_link "グループの新規作成"
       }.to change { current_path }.to login_path
 
-      expect(page).to have_text("ログインしてください")
+      expect(page).to have_text("『ログインしてください』")
     end
 
     scenario "create a private_group and delete a private_group" do

--- a/spec/features/publisher/publisher_create_spec.rb
+++ b/spec/features/publisher/publisher_create_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.feature "PublisherCreates", type: :feature do
+
+  let(:michael)    { FactoryBot.create(:user, name: "michael") }
+
+  feature "creating new publisher" do
+    scenario "redirected login page" do
+      visit root_path
+      click_link "出版社一覧"
+
+      expect {
+        click_link "出版社の新規登録"
+      }.to change { current_path }.to login_path
+
+      expect(page).to have_text("『ログインしてください』")
+    end
+
+    scenario "creating publisher is success" do
+      login(michael)
+
+      visit root_path
+      click_link "出版社一覧"
+      click_link "出版社の新規登録"
+
+      expect {
+        fill_in "publisher[name]", with: "新規テスト出版社"
+        click_button "出版社を追加"
+      }.to change { Publisher.count }.by(1) && change { current_path }.to(publishers_path)
+
+      new_publisher = Publisher.last
+
+      expect(page).to have_text("『新しい出版社を登録しました！』")
+      expect(page).to have_link "新規テスト出版社", href: publisher_path(new_publisher)
+    end
+
+    scenario "creating publisher is failed" do
+      login(michael)
+
+      visit root_path
+      click_link "出版社一覧"
+      click_link "出版社の新規登録"
+
+      expect {
+        fill_in "publisher[name]", with: ""
+        click_button "出版社を追加"
+      }.to_not change { Publisher.count }
+
+      expect(page).to have_text("『出版社の登録に失敗しました...』")
+      expect(page).to have_css('div#validation_messages')
+    end
+  end
+
+end


### PR DESCRIPTION
### 実装内容
* ログインしていない状態で新規登録画面を開いた時の挙動確認
* 新規登録の成功
* 新規登録の失敗