### PR TITLE
参考書の新規登録機能に関するテストを実装

### DIFF
--- a/app/controllers/reference_books_controller.rb
+++ b/app/controllers/reference_books_controller.rb
@@ -23,8 +23,10 @@ class ReferenceBooksController < ApplicationController
     @reference_book = current_user.reference_books.build(reference_book_params)
     @reference_book.image.attach(params[:reference_book][:image])
     if @reference_book.save
-      redirect_to @reference_book.publisher
+      flash[:success] = "新規参考書を登録しました！"
+      redirect_to reference_books_url
     else
+      flash[:danger] = "出版社の登録に失敗しました..."
       render 'new', status: :unprocessable_entity
     end
   end

--- a/app/views/reference_books/_form.html.erb
+++ b/app/views/reference_books/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with(model: @reference_book) do |f| %>
+  <%= render 'shared/error_messages', model: f.object %>
 
   <%= f.label :title, "書籍名" %> <br>
   <%= f.text_field :title, class: 'form-control' %> <br>

--- a/spec/features/publisher/publisher_create_spec.rb
+++ b/spec/features/publisher/publisher_create_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "PublisherCreates", type: :feature do
 
-  let(:michael)    { FactoryBot.create(:user, name: "michael") }
+  let(:michael) { FactoryBot.create(:user, name: "michael") }
 
   feature "creating new publisher" do
     scenario "redirected login page" do

--- a/spec/features/reference_book/reference_book_create_spec.rb
+++ b/spec/features/reference_book/reference_book_create_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature "ReferenceBookCreates", type: :feature do
+
+  before do
+    @user = FactoryBot.create(:user)
+    5.times do
+      FactoryBot.create(:publisher, user_id: @user.id)
+    end
+    @publisher = Publisher.first
+  end
+
+  let(:michael) { FactoryBot.create(:user, name: "michael") }
+
+  feature "creating new reference_book" do
+    scenario "redirected login page" do
+      visit root_path
+
+      click_link "参考書一覧"
+
+      expect {
+        click_link "参考書の新規登録"
+      }.to change { current_path }.to login_path
+
+      expect(page).to have_text("『ログインしてください』")
+    end
+
+    scenario "creating reference_book is success" do
+      login(michael)
+
+      visit root_path
+      click_link "参考書一覧"
+      click_link "参考書の新規登録"
+
+      expect {
+        fill_in "reference_book[title]",   with: "新規書籍(1)"
+        fill_in "reference_book[content]", with: "テスト用の書籍"
+        select  @publisher.name, from: "出版社"
+        click_button "参考書を追加"
+      }.to change { ReferenceBook.count }.by(1) && change { current_path }.to(reference_books_path)
+
+      expect(page).to have_text("『新規参考書を登録しました！』")
+    end
+
+    scenario "creating reference_book is failed" do
+      login(michael)
+
+      visit root_path
+      click_link "参考書一覧"
+      click_link "参考書の新規登録"
+
+      expect {
+        fill_in "reference_book[title]",   with: ""
+        click_button "参考書を追加"
+      }.to_not change { ReferenceBook.count }
+
+      expect(page).to have_text("『出版社の登録に失敗しました...』")
+      expect(page).to have_css('div#validation_messages')
+    end
+  end
+
+end


### PR DESCRIPTION
### 実装内容
* 未ログイン時に作成ページを開いた場合の挙動
* 作成の失敗
* 作成の成功