### PR TITLE
プロフィール画像の削除ボタンのレイアウトを調整

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -268,6 +268,22 @@ aside {
   position: relative;
   padding-top: 4px;
   margin-bottom: 40px;
+  .button {
+    font-size: 14px;
+    margin: 0;
+    width: 200px;
+  }
+  .delete_button {
+    background: #fff;
+    border: 1px #000 solid;
+    color: #000;
+    margin-bottom: 10px;
+    &:hover {
+      color: #ff3300;
+      border: 1px#ff3300 solid;
+      opacity: 1;
+    }
+  }
   .user-name {
     margin-left: 200px;
     line-height: 150px;
@@ -282,6 +298,14 @@ aside {
       border-radius: 50%;
       border: 1px #000 solid;
       object-fit: cover;
+    }
+  }
+  .delete_image {
+    padding: 0;
+    margin: 0;
+    input {
+      font-size: 14px;
+      height: 100%;
     }
   }
   .profile {

--- a/app/views/users/_delete_image.html.erb
+++ b/app/views/users/_delete_image.html.erb
@@ -1,5 +1,5 @@
 <% if current_user?(@user) %>
-  <%= form_with(model: @user) do |f| %>
+  <%= form_with model: @user, class: "delete_image", data: { "turbo-method": :delete, turbo_confirm: "本当に削除しますか？" } do |f| %>
 
     <div><%= f.hidden_field :name %></div>
     <div><%= f.hidden_field :email %></div>
@@ -9,6 +9,6 @@
     <div><%= f.hidden_field :profile %></div>
     <div><%= hidden_field_tag :delete_image, value: true %></div>
 
-    <%= f.submit "プロフィール画像の削除", class: "btn btn-danger" %>
+    <%= f.submit "プロフィール画像の削除", class: "button delete_button" %>
   <% end %>
 <% end %>

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -2,8 +2,7 @@
   <h2 class="user-name"><%= @user.name %></h2>
   <div class="user-image">
     <% if @user.image.attached? %>
-      <%= image_tag @user.image.variant(:display) %>
-      <%= render 'delete_image' %>
+      <%= image_tag @user.image %>
     <% else %>
       <%= image_tag("default-icon.jpeg") %>
     <% end %>
@@ -11,7 +10,8 @@
 
   <% if logged_in? %>
     <% if current_user?(@user) %>
-      <%= link_to "ユーザー情報の編集", edit_user_path(current_user), { class: "button" } if current_user?(@user) %>
+      <%= render 'delete_image' if @user.image.attached? %>
+      <%= link_to "ユーザー情報の編集", edit_user_path(current_user), { class: "button" } %>
     <% else %>
       <%= render 'users/follow/follow_form' %>
     <% end %>


### PR DESCRIPTION
### 実装内容
プロフィール画像を削除するボタンのレイアウトが崩れていたので、修正を行った。